### PR TITLE
Videos/191 - Fix barrel movement

### DIFF
--- a/BattleTank/Source/BattleTank/Private/TankAimingComponent.cpp
+++ b/BattleTank/Source/BattleTank/Private/TankAimingComponent.cpp
@@ -56,11 +56,11 @@ void UTankAimingComponent::AimAt(FVector HitLocation) {
 	bool bHaveAimSolution = UGameplayStatics::SuggestProjectileVelocity(this, OutLaunchVelocity, BarrelLocation, HitLocation, LaunchSpeed, false, 0, 0, ESuggestProjVelocityTraceOption::DoNotTrace);
 	if (bHaveAimSolution) {
 		AimDirection = OutLaunchVelocity.GetSafeNormal();
-		MoveBarrelTowards(AimDirection);
+		MoveBarrelTowards();
 	}
 }
 
-void UTankAimingComponent::MoveBarrelTowards(FVector AimDirection) {
+void UTankAimingComponent::MoveBarrelTowards() {
 	if (!ensure(Barrel) || !ensure(Turret)) { return; }
 
 	// work out differencebetween current barrel rotation and AimDirection
@@ -69,7 +69,12 @@ void UTankAimingComponent::MoveBarrelTowards(FVector AimDirection) {
 	auto DeltaRotator = AimAsRotator - BarrelRotator;
 	
 	Barrel->Elevate(DeltaRotator.Pitch);
-	Turret->Rotate(DeltaRotator.Yaw);
+
+	if (DeltaRotator.Yaw < 180.0) {
+		Turret->Rotate(DeltaRotator.Yaw);
+	} else {
+		Turret->Rotate(-DeltaRotator.Yaw);
+	}
 }
 
 void UTankAimingComponent::Fire()

--- a/BattleTank/Source/BattleTank/Public/TankAimingComponent.h
+++ b/BattleTank/Source/BattleTank/Public/TankAimingComponent.h
@@ -52,7 +52,7 @@ private:
 	UTankBarrel* Barrel = nullptr;
 	UTankTurret* Turret = nullptr;
 
-	void MoveBarrelTowards(FVector AimDirection);
+	void MoveBarrelTowards();
 	bool IsBarrelMoving();
 
 	// Sets default values for this pawn's properties

--- a/BattleTank/Source/BattleTank/TankPlayerController.cpp
+++ b/BattleTank/Source/BattleTank/TankPlayerController.cpp
@@ -25,8 +25,10 @@ void ATankPlayerController::AimTowardsCrosshair() {
 	if (!ensure(AimingComponent)) { return; }
 
 	FVector HitLocation;
+	bool bGotHitLocation = GetSightRayHitLocation(HitLocation);
+	UE_LOG(LogTemp, Warning, TEXT("bGotHitLocation: %i"), bGotHitLocation)
 
-	if (GetSightRayHitLocation(HitLocation)) {
+	if (bGotHitLocation) {
 		AimingComponent->AimAt(HitLocation);
 	}
 }
@@ -43,10 +45,10 @@ bool ATankPlayerController::GetSightRayHitLocation(FVector& HitLocation) const {
 	if (GetLookDirection(ScreenLocation, LookDirection))
 	{
 		// Line-trace along that look direction, and see what we hit (up to a max range)
-		GetLookVectorHitLocation(LookDirection, HitLocation);
+		return GetLookVectorHitLocation(LookDirection, HitLocation);
 	}
 	
-	return true;
+	return false;
 }
 
 bool ATankPlayerController::GetLookDirection(FVector2D ScreenLocation, FVector& LookDirection) const 


### PR DESCRIPTION
Barrel now moves the shortest distance towards the target;

fixed the AimDirection variable, as this was being set as a property as well as being passed to the MoveBarrelTowards method.